### PR TITLE
Update MemcachedCloudServiceProvider.php

### DIFF
--- a/kintso/MemcachedCloud/MemcachedCloudServiceProvider.php
+++ b/kintso/MemcachedCloud/MemcachedCloudServiceProvider.php
@@ -25,7 +25,7 @@ class MemcachedCloudServiceProvider extends ServiceProvider {
             $memcachedCloud = new MemcachedCloudConnector();
             $memcached = $memcachedCloud->connect($servers);
 
-            $this->app->getProviderRepository()->load($this->app, array('Illuminate\Cache\CacheServiceProvider'));
+            $this->app->register('Illuminate\Cache\CacheServiceProvider');
 
             $this->app->make('cache')->extend('memcached', function() use ($memcached) {
                 /** @noinspection PhpUndefinedNamespaceInspection */


### PR DESCRIPTION
Still forces the CacheServiceProvider to be registered, but will do so without rewriting the full services.json file
